### PR TITLE
Multiple streamlits

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -1,0 +1,11 @@
+// Export various constants used by other parts of the app
+const path = require('path')
+
+module.exports = {
+  APPS_DIR: path.join(process.env.HOME, '.streamlit-desktop/apps'),
+  DEFAULT_APP: "my_first_streamlit",
+  DEFAULT_FILENAME: "streamlit_app.py",
+  SERVER_FILE_PATH: path.join(process.env.HOME, '.streamlit-desktop/default_app/synced.py'),
+  DEFAULT_APP_CONTENTS: `import streamlit as st
+st.write("# Hello world!")`,
+}

--- a/forge.config.js
+++ b/forge.config.js
@@ -16,32 +16,19 @@ module.exports = {
   },
   makers: [
     {
-      name: "@electron-forge/maker-squirrel"
-    },
-    {
       name: "@electron-forge/maker-zip",
-      platforms: [
-        "darwin"
-      ],
-      arch: [
-        "x64"
-      ]
-    },
-    {
-      name: "@electron-forge/maker-deb",
       config: {
         options: {
           icon: "icon.png"
         }
       },
       platforms: [
-        "linux"
-      ]
+        "darwin"
+      ],
+      arch: [
+        "x64",
+      ],
     },
-    {
-      name: "@electron-forge/maker-rpm",
-      config: {}
-    }
   ],
   publishers: [
     {
@@ -51,6 +38,12 @@ module.exports = {
           owner: "sfc-gh-zblackwood",
           name: "streamlit-desktop"
         },
+        platforms: [
+          "darwin"
+        ],
+        arch: [
+          "x64",
+        ],
         prerelease: true,
         draft: false,
       }

--- a/forge.config.js
+++ b/forge.config.js
@@ -22,6 +22,9 @@ module.exports = {
       name: "@electron-forge/maker-zip",
       platforms: [
         "darwin"
+      ],
+      arch: [
+        "x64"
       ]
     },
     {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,20 @@
 
     <div id="editor"></div>
 
-    <div class="indicator"></div>
+    <div id="appChooser">
+      <div class="options">
+        <input
+          type="radio"
+          name="app"
+          value="my_first_streamlit"
+          checked="checked"
+        />
+        <label for="my_first_streamlit">my_first_streamlit</label>
+        <input type="radio" name="app" value="my_second_streamlit" />
+        <label for="my_second_streamlit">my_second_streamlit</label>
+      </div>
+      <div class="addNew">+Add new app</div>
+    </div>
 
     <div class="log-label">Logs:</div>
     <br />

--- a/index.html
+++ b/index.html
@@ -12,24 +12,28 @@
   </head>
   <body>
     <h1>Streamlit Desktop</h1>
+
+    <label for="app" class="select-app-label">Select an app</label>
+    <select name="app" id="app-selector">
+      <!--
+      <option value="my_first_streamlit">my_first_streamlit</option>
+      <option value="my_second_streamlit">my_second_streamlit</option>
+      <option value="+Add new app">+Add new app</option>
+      -->
+    </select>
+
+    <input
+      type="text"
+      id="new-app-name"
+      placeholder="New app name"
+      style="display: none"
+    />
+
+    <br />
+    <br />
+
     <span>Change the code here, and see your app previewed on the right</span>
-
     <div id="editor"></div>
-
-    <div id="appChooser">
-      <div class="options">
-        <input
-          type="radio"
-          name="app"
-          value="my_first_streamlit"
-          checked="checked"
-        />
-        <label for="my_first_streamlit">my_first_streamlit</label>
-        <input type="radio" name="app" value="my_second_streamlit" />
-        <label for="my_second_streamlit">my_second_streamlit</label>
-      </div>
-      <div class="addNew">+Add new app</div>
-    </div>
 
     <div class="log-label">Logs:</div>
     <br />

--- a/loading.html
+++ b/loading.html
@@ -7,6 +7,14 @@
     <title>LOADING</title>
   </head>
   <body>
-    <h1>LOADING...</h1>
+    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+    <lottie-player
+      src="https://assets10.lottiefiles.com/packages/lf20_ISCngv3FyB.json"
+      background="transparent"
+      speed="1"
+      style="width: 300px; height: 300px"
+      loop
+      autoplay
+    ></lottie-player>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -133,7 +133,7 @@ const TOTAL_WIDTH = 2000;
 const TOTAL_HEIGHT = 1000;
 const LEFT_WIDTH = 1000;
 const RIGHT_WIDTH = TOTAL_WIDTH - LEFT_WIDTH;
-const LEFT_DEBUGGER = true
+const LEFT_DEBUGGER = false
 const RIGHT_DEBUGGER = false
 
 function createWindow () {

--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ const {app, BrowserWindow, BrowserView, Menu} = require('electron')
 const path = require('path')
 const StreamlitServer = require('./python_environment').StreamlitServer
 const portfinder = require('portfinder');
+const { DEFAULT_APP_CONTENTS, SERVER_FILE_PATH } = require('./consts');
+const fs = require('fs');
 
 const isMac = process.platform === 'darwin'
 
@@ -131,7 +133,7 @@ const TOTAL_WIDTH = 2000;
 const TOTAL_HEIGHT = 1000;
 const LEFT_WIDTH = 1000;
 const RIGHT_WIDTH = TOTAL_WIDTH - LEFT_WIDTH;
-const LEFT_DEBUGGER = false
+const LEFT_DEBUGGER = true
 const RIGHT_DEBUGGER = false
 
 function createWindow () {
@@ -188,11 +190,15 @@ app.whenReady().then(async () => {
     }
   })
 
-
+  if (!fs.existsSync(SERVER_FILE_PATH)) {
+    let = contents = DEFAULT_APP_CONTENTS
+    fs.mkdirSync(path.dirname(SERVER_FILE_PATH), { recursive: true })
+    fs.writeFileSync(SERVER_FILE_PATH, contents)
+  }
 
   if (!streamlit_server) {
       portfinder.getPortPromise({port: 8599}).then(async (port) => {
-        streamlit_server = new StreamlitServer(app, '/tmp/test-sync.py', port);
+        streamlit_server = new StreamlitServer(app, SERVER_FILE_PATH, port);
         let url = await streamlit_server.startOrRestart();
         rightView.webContents.loadURL(url);
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "streamlit-desktop",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "streamlit-desktop",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-python": "6.1.0",
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@electron-forge/cli": "^6.0.0-beta.64",
         "@electron-forge/maker-deb": "^6.0.0-beta.64",
+        "@electron-forge/maker-dmg": "^6.0.4",
         "@electron-forge/maker-rpm": "^6.0.0-beta.64",
         "@electron-forge/maker-squirrel": "^6.0.0-beta.64",
         "@electron-forge/maker-zip": "^6.0.0-beta.64",
@@ -841,6 +842,58 @@
       },
       "optionalDependencies": {
         "electron-installer-debian": "^3.0.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-6.0.4.tgz",
+      "integrity": "sha512-03Q6dVpZu7HdvBFtcZVoCSN0lA3Iqi3H/JjR82G0cWINwgwAKzBlGIcZmkfU+fdBAiO4Z6tUfaYrDDtBhpn1sQ==",
+      "dev": true,
+      "dependencies": {
+        "@electron-forge/maker-base": "^6.0.4",
+        "@electron-forge/shared-types": "^6.0.4",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      },
+      "optionalDependencies": {
+        "electron-installer-dmg": "^4.0.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron-forge/maker-dmg/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron-forge/maker-rpm": {
@@ -2157,6 +2210,42 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/appdmg": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.4.tgz",
+      "integrity": "sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "async": "^1.4.2",
+        "ds-store": "^0.1.5",
+        "execa": "^1.0.0",
+        "fs-temp": "^1.0.0",
+        "fs-xattr": "^0.3.0",
+        "image-size": "^0.7.4",
+        "is-my-json-valid": "^2.20.0",
+        "minimist": "^1.1.3",
+        "parse-color": "^1.0.0",
+        "path-exists": "^4.0.0",
+        "repeat-string": "^1.5.4"
+      },
+      "bin": {
+        "appdmg": "bin/appdmg.js"
+      },
+      "engines": {
+        "node": ">=8.5"
+      }
+    },
+    "node_modules/appdmg/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -2250,6 +2339,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "to-data-view": "^1.1.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2305,6 +2404,16 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "stream-buffers": "~2.2.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2915,6 +3024,18 @@
         "minimatch": "^3.0.4"
       }
     },
+    "node_modules/ds-store": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bplist-creator": "~0.0.3",
+        "macos-alias": "~0.2.5",
+        "tn1150": "^0.1.0"
+      }
+    },
     "node_modules/duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -3258,6 +3379,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/electron-installer-dmg": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-4.0.0.tgz",
+      "integrity": "sha512-g3W6XnyUa7QGrAF7ViewHdt6bXV2KYU1Pm1CY3pZpp+H6mOjCHHAhf/iZAxtaX1ERCb+SQHz7xSsAHuNH9I8ZQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.2",
+        "minimist": "^1.1.1"
+      },
+      "bin": {
+        "electron-installer-dmg": "bin/electron-installer-dmg.js"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "optionalDependencies": {
+        "appdmg": "^0.6.4"
       }
     },
     "node_modules/electron-installer-redhat": {
@@ -3794,6 +3935,13 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -4120,6 +4268,16 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fmix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "imul": "^1.0.0"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -4144,6 +4302,30 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/fs-temp": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
+      "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "random-path": "^0.1.0"
+      }
+    },
+    "node_modules/fs-xattr": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
+      "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -4213,6 +4395,26 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -4651,6 +4853,29 @@
         }
       ]
     },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/imul": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4790,6 +5015,27 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4807,6 +5053,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/is-stream": {
       "version": "1.1.0",
@@ -4888,6 +5141,16 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/junk": {
@@ -5127,6 +5390,20 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/macos-alias": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
+      "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "nan": "^2.4.0"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -5391,6 +5668,25 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/murmur-32": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
+      "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "encode-utf8": "^1.0.3",
+        "fmix": "^0.1.0",
+        "imul": "^1.0.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -5788,6 +6084,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "color-convert": "~0.5.0"
+      }
+    },
+    "node_modules/parse-color/node_modules/color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -6086,6 +6399,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/random-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
+      "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "base32-encode": "^0.1.0 || ^1.0.0",
+        "murmur-32": "^0.1.0 || ^0.2.0"
+      }
+    },
     "node_modules/rcedit": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-3.0.1.tgz",
@@ -6216,6 +6540,16 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -6614,6 +6948,16 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6840,6 +7184,26 @@
         "tmp": "^0.2.0"
       }
     },
+    "node_modules/tn1150": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "unorm": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -6954,6 +7318,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/url-parse-lax": {
@@ -7098,6 +7472,16 @@
       "dev": true,
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -7866,6 +8250,47 @@
         "@electron-forge/maker-base": "^6.0.4",
         "@electron-forge/shared-types": "^6.0.4",
         "electron-installer-debian": "^3.0.0"
+      }
+    },
+    "@electron-forge/maker-dmg": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-6.0.4.tgz",
+      "integrity": "sha512-03Q6dVpZu7HdvBFtcZVoCSN0lA3Iqi3H/JjR82G0cWINwgwAKzBlGIcZmkfU+fdBAiO4Z6tUfaYrDDtBhpn1sQ==",
+      "dev": true,
+      "requires": {
+        "@electron-forge/maker-base": "^6.0.4",
+        "@electron-forge/shared-types": "^6.0.4",
+        "electron-installer-dmg": "^4.0.0",
+        "fs-extra": "^10.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "@electron-forge/maker-rpm": {
@@ -8909,6 +9334,35 @@
         "color-convert": "^2.0.1"
       }
     },
+    "appdmg": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.4.tgz",
+      "integrity": "sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async": "^1.4.2",
+        "ds-store": "^0.1.5",
+        "execa": "^1.0.0",
+        "fs-temp": "^1.0.0",
+        "fs-xattr": "^0.3.0",
+        "image-size": "^0.7.4",
+        "is-my-json-valid": "^2.20.0",
+        "minimist": "^1.1.3",
+        "parse-color": "^1.0.0",
+        "path-exists": "^4.0.0",
+        "repeat-string": "^1.5.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -8980,6 +9434,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "to-data-view": "^1.1.0"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -9021,6 +9485,16 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
+    },
+    "bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "stream-buffers": "~2.2.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9461,6 +9935,18 @@
         "minimatch": "^3.0.4"
       }
     },
+    "ds-store": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
+      "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bplist-creator": "~0.0.3",
+        "macos-alias": "~0.2.5",
+        "tn1150": "^0.1.0"
+      }
+    },
     "duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -9711,6 +10197,18 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "electron-installer-dmg": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-4.0.0.tgz",
+      "integrity": "sha512-g3W6XnyUa7QGrAF7ViewHdt6bXV2KYU1Pm1CY3pZpp+H6mOjCHHAhf/iZAxtaX1ERCb+SQHz7xSsAHuNH9I8ZQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "appdmg": "^0.6.4",
+        "debug": "^4.3.2",
+        "minimist": "^1.1.1"
       }
     },
     "electron-installer-redhat": {
@@ -10109,6 +10607,13 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
+      "dev": true,
+      "optional": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -10362,6 +10867,16 @@
         }
       }
     },
+    "fmix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+      "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "imul": "^1.0.0"
+      }
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -10381,6 +10896,23 @@
       "requires": {
         "minipass": "^3.0.0"
       }
+    },
+    "fs-temp": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
+      "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "random-path": "^0.1.0"
+      }
+    },
+    "fs-xattr": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
+      "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
+      "dev": true,
+      "optional": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -10448,6 +10980,26 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.5"
+      }
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -10790,6 +11342,20 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
+    "image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "dev": true,
+      "optional": true
+    },
+    "imul": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+      "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
+      "dev": true,
+      "optional": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -10896,6 +11462,27 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "dev": true,
+      "optional": true
+    },
+    "is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -10907,6 +11494,13 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -10968,6 +11562,13 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "optional": true
     },
     "junk": {
       "version": "3.1.0",
@@ -11147,6 +11748,16 @@
         "node-addon-api": "^3.1.0",
         "node-gyp-build": "^4.2.1",
         "readable-stream": "^3.6.0"
+      }
+    },
+    "macos-alias": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
+      "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.4.0"
       }
     },
     "make-fetch-happen": {
@@ -11345,6 +11956,25 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "murmur-32": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
+      "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "encode-utf8": "^1.0.3",
+        "fmix": "^0.1.0",
+        "imul": "^1.0.0"
+      }
+    },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "dev": true,
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.3",
@@ -11631,6 +12261,25 @@
         "author-regex": "^1.0.0"
       }
     },
+    "parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "color-convert": "~0.5.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -11849,6 +12498,17 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "random-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
+      "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "base32-encode": "^0.1.0 || ^1.0.0",
+        "murmur-32": "^0.1.0 || ^0.2.0"
+      }
+    },
     "rcedit": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-3.0.1.tgz",
@@ -11949,6 +12609,13 @@
       "requires": {
         "resolve": "^1.20.0"
       }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "optional": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -12248,6 +12915,13 @@
         "minipass": "^3.1.1"
       }
     },
+    "stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "dev": true,
+      "optional": true
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -12432,6 +13106,23 @@
         "tmp": "^0.2.0"
       }
     },
+    "tn1150": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
+      "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "unorm": "^1.4.1"
+      }
+    },
+    "to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
+      "dev": true,
+      "optional": true
+    },
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -12519,6 +13210,13 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true,
+      "optional": true
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -12639,6 +13337,13 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "optional": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "App for developing streamlit applications",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "blackary",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "App for developing streamlit applications",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "blackary",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "App for developing streamlit applications",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "blackary",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "App for developing streamlit applications",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "blackary",
   "scripts": {
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "App for developing streamlit applications",
   "keywords": [],
   "main": "./main.js",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "author": "blackary",
   "scripts": {
     "start": "electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make --arch x64",
-    "publish": "electron-forge publish",
+    "publish": "electron-forge publish --arch x64",
     "lint": "echo \"No linting configured\""
   },
   "dependencies": {
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@electron-forge/cli": "^6.0.0-beta.64",
     "@electron-forge/maker-deb": "^6.0.0-beta.64",
+    "@electron-forge/maker-dmg": "^6.0.4",
     "@electron-forge/maker-rpm": "^6.0.0-beta.64",
     "@electron-forge/maker-squirrel": "^6.0.0-beta.64",
     "@electron-forge/maker-zip": "^6.0.0-beta.64",

--- a/preload.js
+++ b/preload.js
@@ -6,15 +6,48 @@
  * https://www.electronjs.org/docs/latest/tutorial/sandbox
  */
 
-window.addEventListener('DOMContentLoaded', () => {
-  /*
-  const replaceText = (selector, text) => {
-    const element = document.getElementById(selector)
-    if (element) element.innerText = text
-  }
+const DEFAULT_APPS = [
+  "my_first_streamlit",
+  "my_second_streamlit",
+  "my_third_streamlit"
+]
 
-  for (const type of ['chrome', 'node', 'electron']) {
-    replaceText(`${type}-version`, process.versions[type])
+const fs = require('fs');
+const {APPS_DIR} = require('./consts');
+
+const getApps = () => {
+  const apps = fs.readdirSync(APPS_DIR);
+  return apps;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+
+  const apps = getApps();
+  if (apps.length === 0) {
+    apps = DEFAULT_APPS
+    DEFAULT_APPS.forEach(app => {
+      fs.mkdirSync(`${APPS_DIR}/${app}`);
+      let contents = DEFAULT_APP_CONTENTS + `\n"## This is ${selectedApp}"`;
+      fs.writeFileSync(`${APPS_DIR}/${app}/streamlit_app.py`, contents);
+    });
   }
-  */
+  const appSelector = document.getElementById("app-selector")
+
+  apps.forEach(app => {
+    let option = document.createElement("option");
+    option.value = app
+    option.label = app
+    appSelector.appendChild(option);
+  });
+
+  let addNew = document.createElement("option");
+  addNew.value = "add_new"
+  addNew.label = "(Coming soon) Add new app"
+  addNew.disabled = true;
+
+  appSelector.appendChild(addNew);
+
+  appSelector.value = apps[0];
+
+  appSelector.dispatchEvent(new Event('change'));
 })

--- a/preload.js
+++ b/preload.js
@@ -16,18 +16,20 @@ const fs = require('fs');
 const {APPS_DIR} = require('./consts');
 
 const getApps = () => {
-  const apps = fs.readdirSync(APPS_DIR);
-  return apps;
+  try {
+    return fs.readdirSync(APPS_DIR);
+  } catch(e) {
+    return [];
+  }
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-
-  const apps = getApps();
+  let apps = getApps();
   if (apps.length === 0) {
     apps = DEFAULT_APPS
     DEFAULT_APPS.forEach(app => {
-      fs.mkdirSync(`${APPS_DIR}/${app}`);
-      let contents = DEFAULT_APP_CONTENTS + `\n"## This is ${selectedApp}"`;
+      fs.mkdirSync(`${APPS_DIR}/${app}`, { recursive: true });
+      let contents = DEFAULT_APP_CONTENTS + `\n"## This is ${app}"`;
       fs.writeFileSync(`${APPS_DIR}/${app}/streamlit_app.py`, contents);
     });
   }

--- a/python_environment.js
+++ b/python_environment.js
@@ -147,7 +147,7 @@ class StreamlitServer {
       process.stdout.on("data", (data) => {
         console.log(data.toString())
         if (/view your Streamlit app/.test(data)) {
-          resolve('http://localhost:' + this.port)
+          resolve(this.getUrl())
         }
         for (const line of data.toString().split("\n")) {
           this.serverLog(line);
@@ -161,6 +161,9 @@ class StreamlitServer {
     });
   }
 
+  getUrl() {
+    return `http://localhost:${this.port}`;
+  }
 
   shutdown() {
     this.process.kill();

--- a/python_environment.js
+++ b/python_environment.js
@@ -129,8 +129,6 @@ class StreamlitServer {
     const venv_dir = await this.ensureVenv();
     await this.ensurePackagesInstalled();
     const streamlit_bin = path.join(venv_dir, "bin", "streamlit");
-    //this.spawn = spawn
-    //this.process = this.spawn(streamlit_bin,["run", this.file].concat(this.serverArgs()));
 
     return new Promise((resolve, reject) => {
       try {
@@ -184,9 +182,15 @@ class StreamlitServer {
     return versions;
   }
 
-  async ensureVenv() {
+  getEnvDir() {
     const stdesktop_app_dir = path.join(process.env.HOME, ".streamlit-desktop");
     const venv_dir = path.join(stdesktop_app_dir, "envs", this.environment);
+    return venv_dir;
+  }
+
+  async ensureVenv() {
+    const venv_dir = this.getEnvDir();
+    const stdesktop_app_dir = path.join(process.env.HOME, ".streamlit-desktop");
     if (!fs.existsSync(stdesktop_app_dir)) {
       await mkdir(stdesktop_app_dir);
     }

--- a/renderer.js
+++ b/renderer.js
@@ -19,6 +19,7 @@ const { APPS_DIR, DEFAULT_APP, DEFAULT_FILENAME, SERVER_FILE_PATH, DEFAULT_APP_C
 
 
 const editorCodeUpdated = (newCode) => {
+    console.log("UPDATED");
     console.log(newCode);
     fs.writeFileSync(`${APPS_DIR}/${selectedApp}/${DEFAULT_FILENAME}`, newCode);
     fs.writeFileSync(SERVER_FILE_PATH, newCode);
@@ -27,7 +28,7 @@ const editorCodeUpdated = (newCode) => {
 
 
 const editor = new EditorView({
-    doc: DEFAULT_APP_CONTENTS,
+    //doc: DEFAULT_APP_CONTENTS,
     extensions: [
         basicSetup,
         keymap.of([indentWithTab]),
@@ -58,6 +59,16 @@ const editor = new EditorView({
 let selectedApp = DEFAULT_APP;
 
 const selectedAppChanged = (new_app) => {
+    if (new_app === "") {
+        return;
+    }
+    if (new_app === '<Add new app>') {
+
+        if (new_app_name === null) {
+            return;
+        }
+        new_app = new_app_name;
+    }
     console.log(new_app);
     selectedApp = new_app;
     // Create the directory and default file if it doesn't exist
@@ -71,18 +82,19 @@ const selectedAppChanged = (new_app) => {
     replaceEditorContents(app_file);
 }
 
-// Get selected radio button from the app chooser
-let selected = document.querySelector('input[name="app"]:checked');
+// Get selected app from the selectbox
+let selected = document.querySelector('select[name="app"]');
 selectedAppChanged(selected.value);
 
-// Loop through all the radio buttons with the name app and add a click event listener
-document.querySelectorAll('input[name="app"]').forEach((radio) => {
-    radio.addEventListener('click', (event) => {
-        selectedAppChanged(event.target.value);
-    });
-});
+document.querySelector('select[name="app"]').onchange = (event) => {
+    selectedAppChanged(event.target.value);
+};
+
 // Update to initial state
-editorCodeUpdated(editor.state.doc.toString())
+let contents = editor.state.doc.toString();
+if (contents) {
+    editorCodeUpdated(contents);
+}
 
 require('electron').ipcRenderer.on('serverLog', (event, message) => {
     // Send logs to the #logs div

--- a/renderer.js
+++ b/renderer.js
@@ -195,21 +195,7 @@ st.table(sql_data)
             }
         });
     }
-    editor.setState(EditorState.create({
-        doc: contents,
-        extensions: [
-            basicSetup,
-            keymap.of([indentWithTab]),
-            python(),
-            EditorView.updateListener.of((viewUpdate) => {
-                if (viewUpdate.docChanged) {
-                    const doc = viewUpdate.state.doc;
-                    const value = doc.toString();
-                    updated(value);
-                }
-            }),
-        ],
-    }))
+    replaceEditorContents(contents);
 })
 
 var coll = document.getElementsByClassName("collapsible");

--- a/renderer.js
+++ b/renderer.js
@@ -15,31 +15,74 @@ const {python} = require("@codemirror/lang-python")
 const {indentWithTab} = require("@codemirror/commands")
 const fs = require('fs');
 
-const updated = (newCode) => {
+const { APPS_DIR, DEFAULT_APP, DEFAULT_FILENAME, SERVER_FILE_PATH, DEFAULT_APP_CONTENTS } = require('./consts');
+
+
+const editorCodeUpdated = (newCode) => {
     console.log(newCode);
-    fs.writeFileSync('/tmp/test-sync.py', newCode);
+    fs.writeFileSync(`${APPS_DIR}/${selectedApp}/${DEFAULT_FILENAME}`, newCode);
+    fs.writeFileSync(SERVER_FILE_PATH, newCode);
 }
 
-const editor = new EditorView({
-  doc: `import streamlit as st
-st.write("# Hello world!")`,
-  extensions: [
-      basicSetup,
-      keymap.of([indentWithTab]),
-      python(),
-      EditorView.updateListener.of((viewUpdate) => {
-        if (viewUpdate.docChanged) {
-            const doc = viewUpdate.state.doc;
-            const value = doc.toString();
-            updated(value);
-        }
-    }),
-  ],
-  parent: document.getElementById('editor'),
-});
 
+
+const editor = new EditorView({
+    doc: DEFAULT_APP_CONTENTS,
+    extensions: [
+        basicSetup,
+        keymap.of([indentWithTab]),
+        python(),
+        EditorView.updateListener.of((viewUpdate) => {
+          if (viewUpdate.docChanged) {
+              const doc = viewUpdate.state.doc;
+              const value = doc.toString();
+              editorCodeUpdated(value);
+          }
+      }),
+    ],
+    parent: document.getElementById('editor'),
+  });
+
+
+  const replaceEditorContents = (newContents) => {
+      editor.dispatch({
+          changes: {
+              from: 0,
+              to: editor.state.doc.length,
+              insert: newContents
+          }
+      })
+  }
+
+
+let selectedApp = DEFAULT_APP;
+
+const selectedAppChanged = (new_app) => {
+    console.log(new_app);
+    selectedApp = new_app;
+    // Create the directory and default file if it doesn't exist
+    if (!fs.existsSync(`${APPS_DIR}/${selectedApp}`)) {
+        fs.mkdirSync(`${APPS_DIR}/${selectedApp}`, { recursive: true });
+        let contents = DEFAULT_APP_CONTENTS + `\n"## This is ${selectedApp}"`;
+        fs.writeFileSync(`${APPS_DIR}/${selectedApp}/${DEFAULT_FILENAME}`, contents);
+    }
+    // Read the file from the app directory
+    let app_file = fs.readFileSync(`${APPS_DIR}/${selectedApp}/${DEFAULT_FILENAME}`, 'utf8');
+    replaceEditorContents(app_file);
+}
+
+// Get selected radio button from the app chooser
+let selected = document.querySelector('input[name="app"]:checked');
+selectedAppChanged(selected.value);
+
+// Loop through all the radio buttons with the name app and add a click event listener
+document.querySelectorAll('input[name="app"]').forEach((radio) => {
+    radio.addEventListener('click', (event) => {
+        selectedAppChanged(event.target.value);
+    });
+});
 // Update to initial state
-updated(editor.state.doc.toString())
+editorCodeUpdated(editor.state.doc.toString())
 
 require('electron').ipcRenderer.on('serverLog', (event, message) => {
     // Send logs to the #logs div
@@ -56,16 +99,14 @@ require('electron').ipcRenderer.on('processLog', (event, message) => {
 require('electron').ipcRenderer.on('menuItemClick', (event, message) => {
     let contents = "";
     if (message == "Basic") {
-        contents = `import streamlit as st
-st.write("# Hello, world!")
-        `
+        contents = DEFAULT_APP_CONTENTS;
     }
     else if (message == "Plot") {
         contents = `import streamlit as st
 st.write('# Some charts')
 
 st.line_chart({"a": [1,2,3], "b": [2,5,10]})
-        `
+        `;
     }
     else if (message == "Complex") {
         contents = `import streamlit as st
@@ -85,23 +126,8 @@ with tab3:
 num = st.slider("Select number", 1, 10, 3)
 
 st.write(f"{num}^{num}: ", num**num)
-`
+`;
     }
-    editor.setState(EditorState.create({
-        doc: contents,
-        extensions: [
-            basicSetup,
-            keymap.of([indentWithTab]),
-            python(),
-            EditorView.updateListener.of((viewUpdate) => {
-                if (viewUpdate.docChanged) {
-                    const doc = viewUpdate.state.doc;
-                    const value = doc.toString();
-                    updated(value);
-                }
-            }),
-        ],
-    }))
-
-    updated(contents);
-})
+    replaceEditorContents(contents);
+    editorCodeUpdated(contents);
+});

--- a/styles.css
+++ b/styles.css
@@ -113,3 +113,13 @@ textarea {
 
   /* outline-width: 3px; */
 }
+
+select {
+  height: 36px;
+  border: 1px solid #999;
+  font-size: 18px;
+  background-color: #eee;
+  border-radius: 5px;
+  box-shadow: 4px 4px #ccc;
+  padding-left: 3px;
+}


### PR DESCRIPTION
Some notes:
* preload.js prepopulates the list of apps based on the folders in your apps folder
* I couldn't figure out a good way to get input from the user about creating a new one, so I capped it at three :)
* Biggest hack: behind the scenes, streamlit is always just running the same file: `.streamlit-desktop/default_app/synced.py`, but when you make edits, or pick a new app, those edits/selected app get written to BOTH files (e.g. .streamlit-desktop/default_app/synced.py and .streamlit-desktop/apps/my_first_streamlit/streamlit_app.py).
* Theoretically this would also support multiple files, secrets, etc -- you could put anything in the app folder, you would just have to copy over ALL the files into the default_app folder when switching apps